### PR TITLE
test(guard): add vitest to block direct '@/mocks/rpc' imports (regex …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- test(guard): vitest to block direct `@/mocks/rpc` imports
 - chore(types): add shared `src/types/stage.ts` (no behavior change)
 - docs: `docs/DEPLOY_STAGING.md` — staging deployment checklist for Vercel + Railway
 - chore(husky): add pre-commit guard to prevent direct `@/mocks/rpc` imports

--- a/src/tests/no-mock-imports.test.ts
+++ b/src/tests/no-mock-imports.test.ts
@@ -1,0 +1,29 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+function* walk(dir: string): Generator<string> {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) yield* walk(p);
+    else if (s.isFile() && /\.(ts|tsx|js|jsx)$/.test(p)) yield p;
+  }
+}
+
+// Match ONLY actual import statements like: import ... from "@/mocks/rpc"
+const FORBIDDEN = /from\s+['"]@\/mocks\/rpc['"]/;
+
+describe("no direct mocks/rpc imports", () => {
+  it("should not import from '@/mocks/rpc' anywhere in src", () => {
+    const offenders: string[] = [];
+    for (const file of walk("src")) {
+      // ignore this guard test itself
+      if (file.endsWith("src/tests/no-mock-imports.test.ts")) continue;
+
+      const content = readFileSync(file, "utf8");
+      if (FORBIDDEN.test(content)) offenders.push(file);
+    }
+    expect(offenders, `Forbidden '@/mocks/rpc' found in:\n${offenders.join("\n")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
…+ self-exclude)