### PR TITLE
sql(002b): add compat views (unassigned_view, complete_view) -> minim…

### DIFF
--- a/supabase/sql/002b_alias_more_views.sql
+++ b/supabase/sql/002b_alias_more_views.sql
@@ -1,0 +1,12 @@
+-- 002b_alias_more_views.sql — compatibility views for legacy UI
+-- Map legacy names to our new minimal views (read-only)
+
+-- Unassigned counts (legacy screen expects 'unassigned_view')
+create or replace view public.unassigned_view as
+select store, stage, count
+from public.vw_unassigned_counts;
+
+-- Completed (legacy screen expects 'complete_view')
+create or replace view public.complete_view as
+select id, human_id, title, storage_location, store, packing_complete_ts, created_at
+from public.vw_complete_minimal;


### PR DESCRIPTION
…al views

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds read-only legacy compatibility views mapping `unassigned_view` -> `vw_unassigned_counts` and `complete_view` -> `vw_complete_minimal`.
> 
> - **Database (SQL)**
>   - **Compatibility Views (read-only)**:
>     - `public.unassigned_view`: selects `store`, `stage`, `count` from `public.vw_unassigned_counts`.
>     - `public.complete_view`: selects `id`, `human_id`, `title`, `storage_location`, `store`, `packing_complete_ts`, `created_at` from `public.vw_complete_minimal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4c673deea67729a577581c1408249f7de0524ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->