### PR TITLE
Feat/UI unassigned rpc

### DIFF
--- a/src/components/UnassignedStations.tsx
+++ b/src/components/UnassignedStations.tsx
@@ -60,7 +60,8 @@ export function UnassignedStations({ store }: UnassignedStationsProps) {
           filling: data.find(d => d.stage === 'Filling_pending')?.count || 0,
           covering: data.find(d => d.stage === 'Covering_pending')?.count || 0,
           decorating: data.find(d => d.stage === 'Decorating_pending')?.count || 0,
-          packing: data.find(d => d.stage === 'Packing_in_progress')?.count || 0
+          // Packing should reflect UNASSIGNED work → use pending (or normalized "packing")
+          packing: data.find(d => d.stage === 'Packing_pending')?.count || 0
         };
         
         const stationData: Station[] = [

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -7,14 +7,21 @@ export function getSupabase(): SupabaseClient {
   const url = import.meta.env.VITE_SUPABASE_URL;
   const anon = import.meta.env.VITE_SUPABASE_ANON_KEY;
   if (!url || !anon) {
-    throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+    // Do not initialize at import time; throw only when someone tries to use the client
+    throw new Error('Supabase env not configured (VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY)');
   }
-  _client = createClient(url, anon, {
-    auth: { persistSession: false },
-  });
+  _client = createClient(url, anon, { auth: { persistSession: false } });
   return _client;
 }
 
-// Back-compat named + default export
-export const supabase = getSupabase();
+// Back-compat: export an instance-like object that lazily initializes on first property access
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_t, prop) {
+    const c = getSupabase();
+    // @ts-ignore
+    const v = c[prop];
+    return typeof v === 'function' ? v.bind(c) : v;
+  }
+}) as SupabaseClient;
+
 export default supabase;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,10 +1,20 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+let _client: SupabaseClient | null = null;
 
-/**
- * Returns a configured client when envs exist; otherwise a dummy value.
- * Call sites must handle the client possibly being undefined.
- */
-export const supabase = (url && anon) ? createClient(url, anon) : undefined;
+export function getSupabase(): SupabaseClient {
+  if (_client) return _client;
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const anon = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !anon) {
+    throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+  }
+  _client = createClient(url, anon, {
+    auth: { persistSession: false },
+  });
+  return _client;
+}
+
+// Back-compat named + default export
+export const supabase = getSupabase();
+export default supabase;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,2 @@
+export { getSupabase, supabase } from './supabase';
+export default supabase;

--- a/supabase/functions/orders_create_bannos/index.ts
+++ b/supabase/functions/orders_create_bannos/index.ts
@@ -10,14 +10,14 @@ serve(async (req: Request) => {
 
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
 
-  const bodyBytes = new Uint8Array(await req.arrayBuffer());
+  const raw = await req.text();
   const hmac = req.headers.get("x-shopify-hmac-sha256");
 
-  const ok = await verifyShopifyHmac(SECRET, bodyBytes, hmac);
+  const ok = await verifyShopifyHmac(SECRET, raw, hmac);
   if (!ok) return new Response("invalid hmac", { status: 401 });
 
   let payload: any;
-  try { payload = JSON.parse(new TextDecoder().decode(bodyBytes)); }
+  try { payload = JSON.parse(raw); }
   catch {
     return new Response(JSON.stringify({ ok: false, errors: [{ path: 'json', message: 'invalid' }] }), { status: 422, headers: { "content-type": "application/json" } });
   }

--- a/supabase/functions/orders_create_flourlane/index.ts
+++ b/supabase/functions/orders_create_flourlane/index.ts
@@ -10,14 +10,14 @@ serve(async (req: Request) => {
 
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
 
-  const bodyBytes = new Uint8Array(await req.arrayBuffer());
+  const raw = await req.text();
   const hmac = req.headers.get("x-shopify-hmac-sha256");
 
-  const ok = await verifyShopifyHmac(SECRET, bodyBytes, hmac);
+  const ok = await verifyShopifyHmac(SECRET, raw, hmac);
   if (!ok) return new Response("invalid hmac", { status: 401 });
 
   let payload: any;
-  try { payload = JSON.parse(new TextDecoder().decode(bodyBytes)); }
+  try { payload = JSON.parse(raw); }
   catch {
     return new Response(JSON.stringify({ ok: false, errors: [{ path: 'json', message: 'invalid' }] }), { status: 422, headers: { "content-type": "application/json" } });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unassigned UI now reads RPC-provided counts, Supabase client is lazily initialized, and webhook handlers verify/parse raw request text.
> 
> - **UI**:
>   - `src/components/UnassignedStations.tsx`: Replace `get_queue` with `fetchUnassignedCounts(store)` and map counts from `*_pending` stages to station totals.
> - **Supabase Client**:
>   - `src/lib/supabase.ts`: Introduce `getSupabase()` with lazy, env-validated initialization (no session persistence) and a proxy-exported `supabase` instance; add default export.
>   - `src/lib/supabaseClient.ts`: New re-export shim for `getSupabase`/`supabase`.
> - **Edge Functions**:
>   - `supabase/functions/orders_create_*`: Compute HMAC and parse JSON from `req.text()` rather than `arrayBuffer()` to verify and decode payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b65a04f244c9e956a09d487ca73050b60133c616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->