### PR TITLE
Feat/functions orders transform

### DIFF
--- a/src_restore/components/SettingsPage.tsx
+++ b/src_restore/components/SettingsPage.tsx
@@ -101,11 +101,6 @@ export function SettingsPage({ store, onBack }: SettingsPageProps) {
     setHasUnsavedChanges(true);
   };
 
-
-  const handleTestConnection = async (): Promise<boolean> => {
-    if (!settings.shopifyToken.trim()) {
-      toast.error("Please enter a Storefront Access Token");
-      return false;
   const handleTestConnection = async () => {
     if (!settings.shopifyToken.trim()) {
       toast.error("Please enter a Storefront Access Token");
@@ -116,23 +111,6 @@ export function SettingsPage({ store, onBack }: SettingsPageProps) {
     setConnectionStatus('idle');
     
     // Simulate API call
-    await new Promise<void>((resolve) => setTimeout(resolve, 2000));
-    const success = settings.shopifyToken.length > 10; // Mock validation
-    setConnectionStatus(success ? 'success' : 'error');
-    setIsConnecting(false);
-    
-    if (success) {
-      toast.success("Connected successfully");
-      setSettings(prev => ({ ...prev, lastConnected: new Date().toLocaleString() }));
-    } else {
-      toast.error("Connection failed. Check token and permissions.");
-    }
-    return success;
-  };
-
-  const handleConnectAndSync = async () => {
-    const success = await handleTestConnection();
-    if (success) {
     setTimeout(() => {
       const success = settings.shopifyToken.length > 10; // Mock validation
       setConnectionStatus(success ? 'success' : 'error');

--- a/supabase/functions/orders_create_bannos/index.ts
+++ b/supabase/functions/orders_create_bannos/index.ts
@@ -20,10 +20,7 @@ serve(async (req) => {
   if (req.method === "GET" && url.pathname.endsWith("/health")) return new Response("ok", { status: 200 });
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
 
-feat/functions-orders-transform
-  // raw once → HMAC on exact bytes
-
-  const raw = new Uint8Array(await req.arrayBuffer());
+  const raw = new Uint8Array(await req.arrayBuffer()); // read ONCE
   const secret =
     Deno.env.get("SHOPIFY_WEBHOOK_SECRET_BANNOS") ||
     Deno.env.get("SHOPIFY_WEBHOOK_SECRET") || "";
@@ -32,7 +29,7 @@ feat/functions-orders-transform
 
   let payload: any;
   try {
-    const bodyText = new TextDecoder("utf-8").decode(raw);
+    const bodyText = new TextDecoder("utf-8").decode(raw); // decode the SAME bytes
     payload = JSON.parse(bodyText);
   } catch {
     return new Response(JSON.stringify({ ok: false, errors: [{ path: "json", message: "invalid" }] }), {
@@ -42,6 +39,7 @@ feat/functions-orders-transform
 
   const result = normalizeShopifyOrder(payload, "bannos");
   if ((result as any).ok) await tryIngest((result as any).normalized);
+
   const status = (result as any).ok ? 200 : 422;
   return new Response(JSON.stringify(result), { status, headers: { "content-type": "application/json" } });
 });

--- a/supabase/functions/orders_create_bannos/index.ts
+++ b/supabase/functions/orders_create_bannos/index.ts
@@ -17,26 +17,14 @@ async function tryIngest(normalized: unknown) {
 
 serve(async (req) => {
   const url = new URL(req.url);
-feat/functions-orders-transform
-  if (req.method === "GET" && url.pathname.endsWith("/health")) {
-    return new Response("ok", { status: 200 });
-  }
-
-  if (req.method !== "POST") {
-    return new Response("Method Not Allowed", { status: 405 });
-  }
-
-  const raw = new Uint8Array(await req.arrayBuffer());
-  const secret =
-    Deno.env.get("SHOPIFY_WEBHOOK_SECRET_BANNOS") ||
-    Deno.env.get("SHOPIFY_WEBHOOK_SECRET") ||
-    "";
   if (req.method === "GET" && url.pathname.endsWith("/health")) return new Response("ok", { status: 200 });
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
 
-  // raw bytes once → HMAC
+  // raw once → HMAC on exact bytes
   const raw = new Uint8Array(await req.arrayBuffer());
-  const secret = Deno.env.get("SHOPIFY_WEBHOOK_SECRET_BANNOS") || Deno.env.get("SHOPIFY_WEBHOOK_SECRET") || "";
+  const secret =
+    Deno.env.get("SHOPIFY_WEBHOOK_SECRET_BANNOS") ||
+    Deno.env.get("SHOPIFY_WEBHOOK_SECRET") || "";
   const ok = await verifyShopifyHmac(req.headers, raw, secret);
   if (!ok) return new Response("unauthorized", { status: 401 });
 
@@ -47,14 +35,6 @@ feat/functions-orders-transform
     payload = JSON.parse(bodyText);
   } catch {
     return new Response(JSON.stringify({ ok: false, errors: [{ path: "json", message: "invalid" }] }), {
-feat/functions-orders-transform
-      status: 422,
-      headers: { "content-type": "application/json" },
-    });
-  }
-
-  const result = normalizeShopifyOrder(payload, 'bannos');
-  if ((result as any).ok) { await tryIngest((result as any).normalized); }
       status: 422, headers: { "content-type": "application/json" }
     });
   }

--- a/supabase/functions/orders_create_bannos/index.ts
+++ b/supabase/functions/orders_create_bannos/index.ts
@@ -2,26 +2,50 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { verifyShopifyHmac } from "../_shared/hmac.ts";
 import { normalizeShopifyOrder } from "../_shared/order_transform.ts";
 
-// Edge secret to set later in Supabase: SHOPIFY_WEBHOOK_SECRET_BANNOS
-const SECRET = Deno.env.get("SHOPIFY_WEBHOOK_SECRET_BANNOS") ?? "";
+async function tryIngest(normalized: unknown) {
+  try {
+    const url = Deno.env.get("SUPABASE_URL");
+    const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!url || !key) return;
+    await fetch(`${url}/rest/v1/rpc/ingest_order`, {
+      method: "POST",
+      headers: { "content-type": "application/json", apikey: key, authorization: `Bearer ${key}` },
+      body: JSON.stringify({ normalized }),
+    });
+  } catch { /* swallow */ }
+}
 
-serve(async (req: Request) => {
-  if (req.method === "GET") return new Response("ok", { status: 200 }); // /healthz style
+serve(async (req) => {
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname.endsWith("/health")) {
+    return new Response("ok", { status: 200 });
+  }
 
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
 
-  const raw = await req.text();
-  const hmac = req.headers.get("x-shopify-hmac-sha256");
-
-  const ok = await verifyShopifyHmac(SECRET, raw, hmac);
-  if (!ok) return new Response("invalid hmac", { status: 401 });
+  const raw = new Uint8Array(await req.arrayBuffer());
+  const secret =
+    Deno.env.get("SHOPIFY_WEBHOOK_SECRET_BANNOS") ||
+    Deno.env.get("SHOPIFY_WEBHOOK_SECRET") ||
+    "";
+  const ok = await verifyShopifyHmac(req.headers, raw, secret);
+  if (!ok) return new Response("unauthorized", { status: 401 });
 
   let payload: any;
-  try { payload = JSON.parse(raw); }
-  catch {
-    return new Response(JSON.stringify({ ok: false, errors: [{ path: 'json', message: 'invalid' }] }), { status: 422, headers: { "content-type": "application/json" } });
+  try {
+    const bodyText = new TextDecoder("utf-8").decode(raw);
+    payload = JSON.parse(bodyText);
+  } catch {
+    return new Response(JSON.stringify({ ok: false, errors: [{ path: "json", message: "invalid" }] }), {
+      status: 422,
+      headers: { "content-type": "application/json" },
+    });
   }
+
   const result = normalizeShopifyOrder(payload, 'bannos');
+  if ((result as any).ok) { await tryIngest((result as any).normalized); }
   const status = (result as any).ok ? 200 : 422;
   return new Response(JSON.stringify(result), { status, headers: { "content-type": "application/json" } });
 });

--- a/supabase/functions/orders_create_flourlane/index.ts
+++ b/supabase/functions/orders_create_flourlane/index.ts
@@ -2,26 +2,50 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { verifyShopifyHmac } from "../_shared/hmac.ts";
 import { normalizeShopifyOrder } from "../_shared/order_transform.ts";
 
-// Edge secret to set later in Supabase: SHOPIFY_WEBHOOK_SECRET_FLOURLANE
-const SECRET = Deno.env.get("SHOPIFY_WEBHOOK_SECRET_FLOURLANE") ?? "";
+async function tryIngest(normalized: unknown) {
+  try {
+    const url = Deno.env.get("SUPABASE_URL");
+    const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!url || !key) return;
+    await fetch(`${url}/rest/v1/rpc/ingest_order`, {
+      method: "POST",
+      headers: { "content-type": "application/json", apikey: key, authorization: `Bearer ${key}` },
+      body: JSON.stringify({ normalized }),
+    });
+  } catch { /* swallow */ }
+}
 
-serve(async (req: Request) => {
-  if (req.method === "GET") return new Response("ok", { status: 200 }); // /healthz style
+serve(async (req) => {
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname.endsWith("/health")) {
+    return new Response("ok", { status: 200 });
+  }
 
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
 
-  const raw = await req.text();
-  const hmac = req.headers.get("x-shopify-hmac-sha256");
-
-  const ok = await verifyShopifyHmac(SECRET, raw, hmac);
-  if (!ok) return new Response("invalid hmac", { status: 401 });
+  const raw = new Uint8Array(await req.arrayBuffer());
+  const secret =
+    Deno.env.get("SHOPIFY_WEBHOOK_SECRET_FLOURLANE") ||
+    Deno.env.get("SHOPIFY_WEBHOOK_SECRET") ||
+    "";
+  const ok = await verifyShopifyHmac(req.headers, raw, secret);
+  if (!ok) return new Response("unauthorized", { status: 401 });
 
   let payload: any;
-  try { payload = JSON.parse(raw); }
-  catch {
-    return new Response(JSON.stringify({ ok: false, errors: [{ path: 'json', message: 'invalid' }] }), { status: 422, headers: { "content-type": "application/json" } });
+  try {
+    const bodyText = new TextDecoder("utf-8").decode(raw);
+    payload = JSON.parse(bodyText);
+  } catch {
+    return new Response(JSON.stringify({ ok: false, errors: [{ path: "json", message: "invalid" }] }), {
+      status: 422,
+      headers: { "content-type": "application/json" },
+    });
   }
+
   const result = normalizeShopifyOrder(payload, 'flourlane');
+  if ((result as any).ok) { await tryIngest((result as any).normalized); }
   const status = (result as any).ok ? 200 : 422;
   return new Response(JSON.stringify(result), { status, headers: { "content-type": "application/json" } });
 });

--- a/supabase/functions/orders_create_flourlane/index.ts
+++ b/supabase/functions/orders_create_flourlane/index.ts
@@ -61,4 +61,3 @@ feat/functions-orders-transform
   if ((result as any).ok) await tryIngest((result as any).normalized);
   const status = (result as any).ok ? 200 : 422;
   return new Response(JSON.stringify(result), { status, headers: { "content-type": "application/json" } });
-});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure Shopify webhook HMAC uses the exact raw request bytes (single read) and streamline Settings test-connection to return a boolean and gate catalog sync.
> 
> - **Backend (Supabase Edge Functions)**
>   - `supabase/functions/orders_create_bannos/index.ts`, `.../orders_create_flourlane/index.ts`:
>     - Verify HMAC against the exact raw request bytes by reading the body once into `Uint8Array` and decoding the same bytes for JSON parsing.
> - **Frontend**
>   - `src_restore/components/SettingsPage.tsx`:
>     - Refactor `handleTestConnection` to return `boolean`, update connection state handling, and use its result to gate `Connect & Sync` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 859318ebd78138c2096dc97f1dc31fe93b64b0d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->